### PR TITLE
Fixed len of dictionary displayed incorrectly

### DIFF
--- a/tutorials/python/cs228-python-tutorial.ipynb
+++ b/tutorials/python/cs228-python-tutorial.ipynb
@@ -1015,7 +1015,7 @@
        "stream": "stdout",
        "text": [
         "True\n",
-        "2\n"
+        "3\n"
        ]
       }
      ],


### PR DESCRIPTION
When code in the notebook is run in order, the length of the animal's dictionary is supposed to be 3 instead of 2.